### PR TITLE
Use stdlib's 'assertRaises' / 'assertIn' / 'asssertisInstance'

### DIFF
--- a/src/zope/configuration/tests/test_config.py
+++ b/src/zope/configuration/tests/test_config.py
@@ -78,7 +78,7 @@ class ConfigurationContextTests(unittest.TestCase):
         c = self._makeOne()
         with self.assertRaises(ConfigurationError) as exc:
             c.resolve('zope.configuration.tests.nosuch')
-        self.assertTrue('ImportError' in str(exc.exception))
+        self.assertIn('ImportError', str(exc.exception))
 
     def test_resolve_bad_dotted_import(self):
         # Import error caused by a totally wrong dotted name.
@@ -86,7 +86,7 @@ class ConfigurationContextTests(unittest.TestCase):
         c = self._makeOne()
         with self.assertRaises(ConfigurationError) as exc:
             c.resolve('zope.configuration.nosuch.noreally')
-        self.assertTrue('ImportError' in str(exc.exception))
+        self.assertIn('ImportError', str(exc.exception))
 
     def test_resolve_bad_sub_last_import(self):
         #Import error caused by a bad sub import inside the referenced
@@ -498,12 +498,12 @@ class ConfigurationMachineTests(_ConformsToIConfigurationContext,
         self.assertTrue(root.context is cm)
         self.assertEqual(len(cm.i18n_strings), 0)
         # Check bootstrapped meta:*.
-        self.assertTrue((metans, 'directive') in cm._registry)
-        self.assertTrue((metans, 'directives') in cm._registry)
-        self.assertTrue((metans, 'complexDirective') in cm._registry)
-        self.assertTrue((metans, 'groupingDirective') in cm._registry)
-        self.assertTrue((metans, 'provides') in cm._registry)
-        self.assertTrue((metans, 'subdirective') in cm._registry)
+        self.assertIn((metans, 'directive'), cm._registry)
+        self.assertIn((metans, 'directives'), cm._registry)
+        self.assertIn((metans, 'complexDirective'), cm._registry)
+        self.assertIn((metans, 'groupingDirective'), cm._registry)
+        self.assertIn((metans, 'provides'), cm._registry)
+        self.assertIn((metans, 'subdirective'), cm._registry)
 
     def test_begin_w___data_and_kw(self):
         from zope.configuration.config import IConfigurationContext
@@ -1243,7 +1243,7 @@ class GroupingContextDecoratorTests(_ConformsToIConfigurationContext,
         gcd = self._makeOne(context)
         context.foo = 'bar'
         self.assertEqual(gcd.foo, 'bar')
-        self.assertTrue('foo' in gcd.__dict__)
+        self.assertIn('foo', gcd.__dict__)
 
     def test_before(self):
         gcd = self._makeOne()

--- a/src/zope/configuration/tests/test_config.py
+++ b/src/zope/configuration/tests/test_config.py
@@ -494,7 +494,7 @@ class ConfigurationMachineTests(_ConformsToIConfigurationContext,
         self.assertEqual(len(cm.actions), 0)
         self.assertEqual(len(cm.stack), 1)
         root = cm.stack[0]
-        self.assertTrue(isinstance(root, RootStackItem))
+        self.assertIsInstance(root, RootStackItem)
         self.assertTrue(root.context is cm)
         self.assertEqual(len(cm.i18n_strings), 0)
         # Check bootstrapped meta:*.
@@ -542,7 +542,7 @@ class ConfigurationMachineTests(_ConformsToIConfigurationContext,
                                  }, 'INFO')
         self.assertEqual(len(cm.stack), 2)
         root = cm.stack[0]
-        self.assertTrue(isinstance(root, RootStackItem))
+        self.assertIsInstance(root, RootStackItem)
         nested = cm.stack[1]
         self.assertTrue(nested is item)
         self.assertEqual(_called_with,
@@ -579,7 +579,7 @@ class ConfigurationMachineTests(_ConformsToIConfigurationContext,
                 )
         self.assertEqual(len(cm.stack), 2)
         root = cm.stack[0]
-        self.assertTrue(isinstance(root, RootStackItem))
+        self.assertIsInstance(root, RootStackItem)
         nested = cm.stack[1]
         self.assertTrue(nested is item)
         self.assertEqual(_called_with,
@@ -601,7 +601,7 @@ class ConfigurationMachineTests(_ConformsToIConfigurationContext,
         cm.end()
         self.assertEqual(len(cm.stack), 1)
         root = cm.stack[0]
-        self.assertTrue(isinstance(root, RootStackItem))
+        self.assertIsInstance(root, RootStackItem)
         self.assertTrue(item._finished)
 
     def test___call__(self):
@@ -635,7 +635,7 @@ class ConfigurationMachineTests(_ConformsToIConfigurationContext,
            )
         self.assertEqual(len(cm.stack), 1)
         root = cm.stack[0]
-        self.assertTrue(isinstance(root, RootStackItem))
+        self.assertIsInstance(root, RootStackItem)
         self.assertEqual(_called_with,
                         [(cm, {'name': 'testing',
                                'schema': ISchema,
@@ -815,7 +815,7 @@ class SimpleStackItemTests(_ConformsToIStackItem,
             pass
         _data = {}
         ssi = self._makeOne(context, _handler, 'INFO', ISchema, _data)
-        self.assertTrue(isinstance(ssi.context, GroupingContextDecorator))
+        self.assertIsInstance(ssi.context, GroupingContextDecorator)
         self.assertTrue(ssi.context.context is context)
         self.assertEqual(ssi.context.info, 'INFO')
         self.assertEqual(ssi.handler, _handler)
@@ -1083,7 +1083,7 @@ class ComplexStackItemTests(_ConformsToIStackItem,
         context = FauxContext()
         _data = {'name': 'NAME'}
         csi = self._makeOne(meta, context, _data, 'INFO')
-        self.assertTrue(isinstance(csi.context, GroupingContextDecorator))
+        self.assertIsInstance(csi.context, GroupingContextDecorator)
         self.assertTrue(csi.context.context is context)
         self.assertEqual(csi.context.info, 'INFO')
         self.assertEqual(csi.handler, meta._handler)
@@ -1115,8 +1115,8 @@ class ComplexStackItemTests(_ConformsToIStackItem,
         _data = {'name': 'NAME'}
         csi = self._makeOne(meta, context, _data, 'INFO')
         ssi = csi.contained((NS, NAME), {}, 'SUBINFO')
-        self.assertTrue(isinstance(ssi, SimpleStackItem))
-        self.assertTrue(isinstance(ssi.context, GroupingContextDecorator))
+        self.assertIsInstance(ssi, SimpleStackItem)
+        self.assertIsInstance(ssi.context, GroupingContextDecorator)
         self.assertTrue(ssi.context.context is csi.context)
         self.assertEqual(ssi.context.info, 'SUBINFO')
         self.assertEqual(ssi.handler, wn.testing)

--- a/src/zope/configuration/tests/test_fields.py
+++ b/src/zope/configuration/tests/test_fields.py
@@ -150,7 +150,7 @@ class GlobalInterfaceTests(unittest.TestCase, _ConformsToIFromUnicode):
     def test_ctor(self):
         from zope.schema import InterfaceField
         gi = self._makeOne()
-        self.assertTrue(isinstance(gi.value_type, InterfaceField))
+        self.assertIsInstance(gi.value_type, InterfaceField)
 
 class TokensTests(unittest.TestCase, _ConformsToIFromUnicode):
 

--- a/src/zope/configuration/tests/test_fields.py
+++ b/src/zope/configuration/tests/test_fields.py
@@ -55,8 +55,8 @@ class PythonIdentifierTests(unittest.TestCase, _ConformsToIFromUnicode):
         from zope.schema import ValidationError
         from zope.configuration._compat import u
         pi = self._makeOne()
-        self.assertRaises(ValidationError,
-                          pi._validate, u('not-an-identifier'))
+        with self.assertRaises(ValidationError):
+            pi._validate(u('not-an-identifier'))
 
     def test__validate_hit(self):
         from zope.configuration._compat import u
@@ -88,7 +88,8 @@ class GlobalObjectTests(unittest.TestCase, _ConformsToIFromUnicode):
         go = self._makeOne(value_type=Text())
         go.validate(u(''))
         for value in [0, 0.0, (), [], set(), frozenset(), b('')]:
-            self.assertRaises(WrongType, go._validate, value)
+            with self.assertRaises(WrongType):
+                go._validate(value)
 
     def test_fromUnicode_w_star_and_extra_ws(self):
         go = self._makeOne()
@@ -104,7 +105,8 @@ class GlobalObjectTests(unittest.TestCase, _ConformsToIFromUnicode):
         go = self._makeOne()
         context = Context()
         bound = go.bind(context)
-        self.assertRaises(ValidationError, bound.fromUnicode, 'tried')
+        with self.assertRaises(ValidationError):
+            bound.fromUnicode('tried')
         self.assertEqual(context._resolved, 'tried')
 
     def test_fromUnicode_w_resolve_success(self):
@@ -131,7 +133,8 @@ class GlobalObjectTests(unittest.TestCase, _ConformsToIFromUnicode):
         go = self._makeOne(value_type=Text())
         context = Context()
         bound = go.bind(context)
-        self.assertRaises(ValidationError, bound.fromUnicode, 'tried')
+        with self.assertRaises(ValidationError):
+            bound.fromUnicode('tried')
         self.assertEqual(context._resolved, 'tried')
 
 
@@ -176,8 +179,8 @@ class TokensTests(unittest.TestCase, _ConformsToIFromUnicode):
         from zope.configuration._compat import u
         tok = self._makeOne(value_type=Int(min=0))
         context = object()
-        self.assertRaises(InvalidToken,
-                          tok.fromUnicode, u(' 1 -1 3 '))
+        with self.assertRaises(InvalidToken):
+            tok.fromUnicode(u(' 1 -1 3 '))
 
 
 class PathTests(unittest.TestCase, _ConformsToIFromUnicode):
@@ -232,7 +235,8 @@ class BoolTests(unittest.TestCase, _ConformsToIFromUnicode):
     def test_fromUnicode_w_invalid(self):
         from zope.schema import ValidationError
         bo = self._makeOne()
-        self.assertRaises(ValidationError, bo.fromUnicode, 'notvalid')
+        with self.assertRaises(ValidationError):
+            bo.fromUnicode('notvalid')
 
 
 class MessageIDTests(unittest.TestCase, _ConformsToIFromUnicode):

--- a/src/zope/configuration/tests/test_name.py
+++ b/src/zope/configuration/tests/test_name.py
@@ -113,8 +113,8 @@ class Test_path(unittest.TestCase):
                          os.path.normpath(absolute_path))
 
     def test_relative_bogus_package(self):
-        self.assertRaises(ImportError,
-                          self._callFUT, '', 'no.such.package.exists')
+        with self.assertRaises(ImportError):
+            self._callFUT('', 'no.such.package.exists')
 
     def test_relative_empty(self):
         import os

--- a/src/zope/configuration/tests/test_xmlconfig.py
+++ b/src/zope/configuration/tests/test_xmlconfig.py
@@ -28,21 +28,6 @@ B = u('b')
 BVALUE = u('bvalue')
 
 
-class _Catchable(object):
-    # Mixin for classes which need to make assertions about the exception
-    # instance.
-    def assertRaises(self, excClass, callableObj, *args, **kwargs):
-        # Morph stdlib version to return the raised exception
-        try:
-            callableObj(*args, **kwargs)
-        except excClass as exc:
-            return exc
-        if hasattr(excClass,'__name__'):
-            excName = excClass.__name__
-        else:
-            excName = str(excClass)
-        raise self.failureException("%s not raised" % excName)
-
 
 class ZopeXMLConfigurationErrorTests(unittest.TestCase):
 
@@ -123,7 +108,7 @@ class ParserInfoTests(unittest.TestCase):
             '    <directives namespace="http://namespaces.zope.org/zope">')
 
 
-class ConfigurationHandlerTests(_Catchable, unittest.TestCase):
+class ConfigurationHandlerTests(unittest.TestCase):
 
     def _getTargetClass(self):
         from zope.configuration.xmlconfig import ConfigurationHandler
@@ -188,15 +173,17 @@ class ConfigurationHandlerTests(_Catchable, unittest.TestCase):
         locator = FauxLocator('tests//sample.zcml', 1, 1)
         handler = self._makeOne(context)
         handler.setDocumentLocator(locator)
-        exc = self.assertRaises(ZopeXMLConfigurationError,
-                    handler.startElementNS, (NS, FOO), FOO,
-                                     {(XXX, SPLAT): SPLATV,
-                                      (None, A): AVALUE,
-                                      (None, B): BVALUE,
-                                     })
-        self.assertEqual(exc.info.file, 'tests//sample.zcml')
-        self.assertEqual(exc.info.line, 1)
-        self.assertEqual(exc.info.column, 1)
+        with self.assertRaises(ZopeXMLConfigurationError) as exc:
+            handler.startElementNS(
+                (NS, FOO),
+                FOO,
+                {(XXX, SPLAT): SPLATV,
+                 (None, A): AVALUE,
+                 (None, B): BVALUE,
+                })
+        self.assertEqual(exc.exception.info.file, 'tests//sample.zcml')
+        self.assertEqual(exc.exception.info.line, 1)
+        self.assertEqual(exc.exception.info.column, 1)
 
     def test_startElementNS_context_begin_raises_w_testing(self):
         class ErrorContext(FauxContext):
@@ -206,12 +193,13 @@ class ConfigurationHandlerTests(_Catchable, unittest.TestCase):
         locator = FauxLocator('tests//sample.zcml', 1, 1)
         handler = self._makeOne(context, True)
         handler.setDocumentLocator(locator)
-        self.assertRaises(AttributeError,
-                    handler.startElementNS, (NS, FOO), FOO,
-                                     {(XXX, SPLAT): SPLATV,
-                                      (None, A): AVALUE,
-                                      (None, B): BVALUE,
-                                     })
+        with self.assertRaises(AttributeError):
+            handler.startElementNS(
+                (NS, FOO), FOO,
+                {(XXX, SPLAT): SPLATV,
+                 (None, A): AVALUE,
+                 (None, B): BVALUE,
+                })
 
     def test_startElementNS_normal(self):
         # Integration test of startElementNS / endElementNS pair.
@@ -258,11 +246,11 @@ class ConfigurationHandlerTests(_Catchable, unittest.TestCase):
         handler = self._makeOne(context)
         handler.setDocumentLocator(locator)
         locator.line, locator.column = 7, 16
-        exc = self.assertRaises(ZopeXMLConfigurationError,
-                          handler.endElementNS, (NS, FOO), FOO)
-        self.assertTrue(exc.info is context.info)
-        self.assertEqual(exc.info._line, 7)
-        self.assertEqual(exc.info._col, 16)
+        with self.assertRaises(ZopeXMLConfigurationError) as exc:
+            handler.endElementNS((NS, FOO), FOO)
+        self.assertTrue(exc.exception.info is context.info)
+        self.assertEqual(exc.exception.info._line, 7)
+        self.assertEqual(exc.exception.info._col, 16)
 
     def test_endElementNS_context_end_raises_w_testing(self):
         class ErrorContext(FauxContext):
@@ -279,24 +267,25 @@ class ConfigurationHandlerTests(_Catchable, unittest.TestCase):
         handler = self._makeOne(context, True)
         handler.setDocumentLocator(locator)
         locator.line, locator.column = 7, 16
-        self.assertRaises(AttributeError,
-                          handler.endElementNS, (NS, FOO), FOO)
+        with self.assertRaises(AttributeError):
+            handler.endElementNS((NS, FOO), FOO)
         self.assertEqual(context.info._line, 7)
         self.assertEqual(context.info._col, 16)
 
     def test_evaluateCondition_w_have_no_args(self):
         context = FauxContext()
         handler = self._makeOne(context)
-        exc = self.assertRaises(ValueError,
-                                handler.evaluateCondition, 'have')
-        self.assertEqual(str(exc.args[0]), "Feature name missing: 'have'")
+        with self.assertRaises(ValueError) as exc:
+            handler.evaluateCondition('have')
+        self.assertEqual(str(exc.exception.args[0]),
+                         "Feature name missing: 'have'")
 
     def test_evaluateCondition_w_not_have_too_many_args(self):
         context = FauxContext()
         handler = self._makeOne(context)
-        exc = self.assertRaises(ValueError,
-                                handler.evaluateCondition, 'not-have a b')
-        self.assertEqual(str(exc.args[0]),
+        with self.assertRaises(ValueError) as exc:
+            handler.evaluateCondition('not-have a b')
+        self.assertEqual(str(exc.exception.args[0]),
                          "Only one feature allowed: 'not-have a b'")
 
     def test_evaluateCondition_w_have_miss(self):
@@ -324,22 +313,24 @@ class ConfigurationHandlerTests(_Catchable, unittest.TestCase):
     def test_evaluateCondition_w_installed_no_args(self):
         context = FauxContext()
         handler = self._makeOne(context)
-        exc = self.assertRaises(ValueError,
-                                handler.evaluateCondition, 'installed')
-        self.assertEqual(str(exc.args[0]), "Package name missing: 'installed'")
+        with self.assertRaises(ValueError) as exc:
+                handler.evaluateCondition('installed')
+        self.assertEqual(str(exc.exception.args[0]),
+                         "Package name missing: 'installed'")
 
     def test_evaluateCondition_w_not_installed_too_many_args(self):
         context = FauxContext()
         handler = self._makeOne(context)
-        exc = self.assertRaises(ValueError,
-                                handler.evaluateCondition, 'not-installed a b')
-        self.assertEqual(str(exc.args[0]),
+        with self.assertRaises(ValueError) as exc:
+            handler.evaluateCondition('not-installed a b')
+        self.assertEqual(str(exc.exception.args[0]),
                          "Only one package allowed: 'not-installed a b'")
 
     def test_evaluateCondition_w_installed_miss(self):
         context = FauxContext()
         handler = self._makeOne(context)
-        self.assertFalse(handler.evaluateCondition('installed nonsuch.package'))
+        self.assertFalse(
+            handler.evaluateCondition('installed nonsuch.package'))
 
     def test_evaluateCondition_w_installed_hit(self):
         context = FauxContext()
@@ -360,9 +351,9 @@ class ConfigurationHandlerTests(_Catchable, unittest.TestCase):
     def test_evaluateCondition_w_unknown_verb(self):
         context = FauxContext()
         handler = self._makeOne(context)
-        exc = self.assertRaises(ValueError,
-                                handler.evaluateCondition, 'nonesuch')
-        self.assertEqual(str(exc.args[0]),
+        with self.assertRaises(ValueError) as exc:
+            handler.evaluateCondition('nonesuch')
+        self.assertEqual(str(exc.exception.args[0]),
                          "Invalid ZCML condition: 'nonesuch'")
 
     def test_endElementNS_normal(self):
@@ -382,7 +373,7 @@ class ConfigurationHandlerTests(_Catchable, unittest.TestCase):
         self.assertTrue(context._end_called)
 
 
-class Test_processxmlfile(_Catchable, unittest.TestCase):
+class Test_processxmlfile(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from zope.configuration.xmlconfig import processxmlfile
@@ -395,9 +386,10 @@ class Test_processxmlfile(_Catchable, unittest.TestCase):
         from zope.configuration._compat import StringIO
         context = ConfigurationMachine()
         registerCommonDirectives(context)
-        exc = self.assertRaises(ZopeSAXParseException,
-                                self._callFUT, StringIO(), context)
-        self.assertEqual(str(exc._v), '<string>:1:0: no element found')
+        with self.assertRaises(ZopeSAXParseException) as exc:
+            self._callFUT(StringIO(), context)
+        self.assertEqual(str(exc.exception._v),
+                         '<string>:1:0: no element found')
 
     def test_w_valid_xml_fp(self):
         # Integration test, really
@@ -422,7 +414,7 @@ class Test_processxmlfile(_Catchable, unittest.TestCase):
         self.assertEqual(data.basepath, None)
 
 
-class Test_openInOrPlain(_Catchable, unittest.TestCase):
+class Test_openInOrPlain(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from zope.configuration.xmlconfig import openInOrPlain
@@ -445,13 +437,12 @@ class Test_openInOrPlain(_Catchable, unittest.TestCase):
 
     def test_file_missing_and_dot_in_not_present(self):
         import errno
-        exc = self.assertRaises(
-                IOError,
-                self._callFUT, self._makeFilename('nonesuch.zcml'))
-        self.assertEqual(exc.errno, errno.ENOENT)
+        with self.assertRaises(IOError) as exc:
+            self._callFUT(self._makeFilename('nonesuch.zcml'))
+        self.assertEqual(exc.exception.errno, errno.ENOENT)
 
 
-class Test_include(_Catchable, unittest.TestCase):
+class Test_include(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from zope.configuration.xmlconfig import include
@@ -459,10 +450,11 @@ class Test_include(_Catchable, unittest.TestCase):
 
     def test_both_file_and_files_passed(self):
         context = FauxContext()
-        exc = self.assertRaises(ValueError,
-                                self._callFUT, context, 'tests//sample.zcml',
-                                files=['tests/*.zcml'])
-        self.assertEqual(str(exc), "Must specify only one of file or files")
+        with self.assertRaises(ValueError) as exc:
+            self._callFUT(
+                context, 'tests//sample.zcml', files=['tests/*.zcml'])
+        self.assertEqual(str(exc.exception),
+                         "Must specify only one of file or files")
 
     def test_neither_file_nor_files_passed_already_seen(self):
         from zope.configuration import xmlconfig
@@ -578,7 +570,7 @@ class Test_include(_Catchable, unittest.TestCase):
         self.assertTrue(fqn3 in context._seen_files)
 
 
-class Test_exclude(_Catchable, unittest.TestCase):
+class Test_exclude(unittest.TestCase):
 
     def _callFUT(self, *args, **kw):
         from zope.configuration.xmlconfig import exclude
@@ -586,10 +578,11 @@ class Test_exclude(_Catchable, unittest.TestCase):
 
     def test_both_file_and_files_passed(self):
         context = FauxContext()
-        exc = self.assertRaises(ValueError,
-                                self._callFUT, context, 'tests//sample.zcml',
-                                files=['tests/*.zcml'])
-        self.assertEqual(str(exc), "Must specify only one of file or files")
+        with self.assertRaises(ValueError) as exc:
+            self._callFUT(
+                context, 'tests//sample.zcml', files=['tests/*.zcml'])
+        self.assertEqual(str(exc.exception),
+                         "Must specify only one of file or files")
 
     def test_neither_file_nor_files_passed(self):
         from zope.configuration.config import ConfigurationMachine
@@ -716,7 +709,8 @@ class Test_file(unittest.TestCase):
         self.assertEqual(len(foo.data), 0)
         self.assertEqual(len(context.actions), 1)
         action = context.actions[0]
-        self.assertEqual(action['discriminator'], (('x', b('blah')), ('y', 0)))
+        self.assertEqual(action['discriminator'],
+                         (('x', b('blah')), ('y', 0)))
         self.assertEqual(action['callable'], foo.data.append)
 
     def test_wo_execute_wo_context_w_package(self):
@@ -735,7 +729,8 @@ class Test_file(unittest.TestCase):
         self.assertTrue(context.package is samplepackage)
         self.assertEqual(len(context.actions), 1)
         action = context.actions[0]
-        self.assertEqual(action['discriminator'], (('x', b('blah')), ('y', 0)))
+        self.assertEqual(action['discriminator'],
+                         (('x', b('blah')), ('y', 0)))
         self.assertEqual(action['callable'], foo.data.append)
 
     def test_wo_execute_w_context(self):
@@ -759,7 +754,8 @@ class Test_file(unittest.TestCase):
         self.assertEqual(len(foo.data), 0)
         self.assertEqual(len(context.actions), 1)
         action = context.actions[0]
-        self.assertEqual(action['discriminator'], (('x', b('blah')), ('y', 0)))
+        self.assertEqual(action['discriminator'],
+                         (('x', b('blah')), ('y', 0)))
         self.assertEqual(action['callable'], foo.data.append)
 
     def test_w_execute(self):
@@ -775,8 +771,9 @@ class Test_file(unittest.TestCase):
         self.assertEqual(logger.debugs[0], ('include %s' % file_name, (), {}))
         data = foo.data.pop()
         self.assertEqual(data.args, (('x', b('blah')), ('y', 0)))
-        self.assertTrue(data.info.file.endswith(
-                        os.path.normpath('tests/samplepackage/configure.zcml')))
+        self.assertTrue(
+            data.info.file.endswith(
+                os.path.normpath('tests/samplepackage/configure.zcml')))
         self.assertEqual(data.info.line, 12)
         self.assertEqual(data.info.column, 2)
         self.assertEqual(data.info.eline, 12)
@@ -802,7 +799,8 @@ class Test_string(unittest.TestCase):
         self.assertEqual(len(foo.data), 0)
         self.assertEqual(len(context.actions), 1)
         action = context.actions[0]
-        self.assertEqual(action['discriminator'], (('x', b('blah')), ('y', 0)))
+        self.assertEqual(action['discriminator'],
+                         (('x', b('blah')), ('y', 0)))
         self.assertEqual(action['callable'], foo.data.append)
 
     def test_wo_execute_w_context(self):
@@ -820,7 +818,8 @@ class Test_string(unittest.TestCase):
         self.assertEqual(len(foo.data), 0)
         self.assertEqual(len(context.actions), 1)
         action = context.actions[0]
-        self.assertEqual(action['discriminator'], (('x', b('blah')), ('y', 0)))
+        self.assertEqual(action['discriminator'],
+                         (('x', b('blah')), ('y', 0)))
         self.assertEqual(action['callable'], foo.data.append)
 
     def test_w_execute(self):
@@ -878,7 +877,8 @@ class XMLConfigTests(unittest.TestCase):
         self.assertEqual(len(foo.data), 0) # no execut_actions
         self.assertEqual(len(xc.context.actions), 1)
         action = xc.context.actions[0]
-        self.assertEqual(action['discriminator'], (('x', b('blah')), ('y', 0)))
+        self.assertEqual(action['discriminator'],
+                         (('x', b('blah')), ('y', 0)))
         self.assertEqual(action['callable'], foo.data.append)
 
     def test_ctor(self):
@@ -895,7 +895,8 @@ class XMLConfigTests(unittest.TestCase):
         self.assertEqual(len(foo.data), 0) # no execut_actions
         self.assertEqual(len(xc.context.actions), 1)
         action = xc.context.actions[0]
-        self.assertEqual(action['discriminator'], (('x', b('blah')), ('y', 0)))
+        self.assertEqual(action['discriminator'],
+                         (('x', b('blah')), ('y', 0)))
         self.assertEqual(action['callable'], foo.data.append)
 
     def test_ctor_w_module(self):
@@ -912,7 +913,8 @@ class XMLConfigTests(unittest.TestCase):
         self.assertEqual(len(foo.data), 0) # no execut_actions
         self.assertEqual(len(xc.context.actions), 1)
         action = xc.context.actions[0]
-        self.assertEqual(action['discriminator'], (('x', b('blah')), ('y', 0)))
+        self.assertEqual(action['discriminator'],
+                         (('x', b('blah')), ('y', 0)))
         self.assertEqual(action['callable'], foo.data.append)
 
     def test___call__(self):
@@ -932,8 +934,9 @@ class XMLConfigTests(unittest.TestCase):
         self.assertEqual(len(foo.data), 1)
         data = foo.data.pop(0)
         self.assertEqual(data.args, (('x', b('blah')), ('y', 0)))
-        self.assertTrue(data.info.file.endswith(
-                        os.path.normpath('tests/samplepackage/configure.zcml')))
+        self.assertTrue(
+            data.info.file.endswith(
+                os.path.normpath('tests/samplepackage/configure.zcml')))
         self.assertEqual(data.info.line, 12)
         self.assertEqual(data.info.column, 2)
         self.assertEqual(data.info.eline, 12)
@@ -980,8 +983,9 @@ class Test_xmlconfig(unittest.TestCase):
         self.assertEqual(len(foo.data), 1)
         data = foo.data.pop(0)
         self.assertEqual(data.args, (('x', b('blah')), ('y', 0)))
-        self.assertTrue(data.info.file.endswith(
-                        os.path.normpath('tests/samplepackage/configure.zcml')))
+        self.assertTrue(
+            data.info.file.endswith(
+                os.path.normpath('tests/samplepackage/configure.zcml')))
         self.assertEqual(data.info.line, 12)
         self.assertEqual(data.info.column, 2)
         self.assertEqual(data.info.eline, 12)
@@ -1008,8 +1012,9 @@ class Test_xmlconfig(unittest.TestCase):
         self.assertEqual(len(foo.data), 1)
         data = foo.data.pop(0)
         self.assertEqual(data.args, (('x', b('blah')), ('y', 0)))
-        self.assertTrue(data.info.file.endswith(
-                        os.path.normpath('tests/samplepackage/configure.zcml')))
+        self.assertTrue(
+            data.info.file.endswith(
+                os.path.normpath('tests/samplepackage/configure.zcml')))
         self.assertEqual(data.info.line, 12)
         self.assertEqual(data.info.column, 2)
         self.assertEqual(data.info.eline, 12)
@@ -1055,8 +1060,9 @@ class Test_testxmlconfig(unittest.TestCase):
         self.assertEqual(len(foo.data), 1)
         data = foo.data.pop(0)
         self.assertEqual(data.args, (('x', b('blah')), ('y', 0)))
-        self.assertTrue(data.info.file.endswith(
-                        os.path.normpath('tests/samplepackage/configure.zcml')))
+        self.assertTrue(
+            data.info.file.endswith(
+                os.path.normpath('tests/samplepackage/configure.zcml')))
         self.assertEqual(data.info.line, 12)
         self.assertEqual(data.info.column, 2)
         self.assertEqual(data.info.eline, 12)

--- a/src/zope/configuration/tests/test_xmlconfig.py
+++ b/src/zope/configuration/tests/test_xmlconfig.py
@@ -556,12 +556,12 @@ class Test_include(unittest.TestCase):
         action = context.actions[0]
         self.assertEqual(action['callable'], foo.data.append)
         self.assertEqual(action['includepath'], (fqn2,))
-        self.assertTrue(isinstance(action['args'][0], foo.stuff))
+        self.assertIsInstance(action['args'][0], foo.stuff)
         self.assertEqual(action['args'][0].args, (('x', b('foo')), ('y', 2)))
         action = context.actions[1]
         self.assertEqual(action['callable'], foo.data.append)
         self.assertEqual(action['includepath'], (fqn3,))
-        self.assertTrue(isinstance(action['args'][0], foo.stuff))
+        self.assertIsInstance(action['args'][0], foo.stuff)
         self.assertEqual(action['args'][0].args, (('x', b('foo')), ('y', 3)))
         self.assertEqual(context.stack, before_stack)
         self.assertEqual(len(context._seen_files), 3)

--- a/src/zope/configuration/tests/test_xmlconfig.py
+++ b/src/zope/configuration/tests/test_xmlconfig.py
@@ -494,7 +494,7 @@ class Test_include(unittest.TestCase):
         self.assertEqual(action['includepath'], (fqn,))
         self.assertEqual(context.stack, before_stack)
         self.assertEqual(len(context._seen_files), 1)
-        self.assertTrue(fqn in context._seen_files)
+        self.assertIn(fqn, context._seen_files)
 
     def test_w_file_passed(self):
         from zope.configuration import xmlconfig
@@ -530,7 +530,7 @@ class Test_include(unittest.TestCase):
                          _packageFile(tests, '__init__.py'))
         self.assertEqual(context.stack, before_stack)
         self.assertEqual(len(context._seen_files), 1)
-        self.assertTrue(fqn in context._seen_files)
+        self.assertIn(fqn, context._seen_files)
 
     def test_w_files_passed_and_package(self):
         from zope.configuration import xmlconfig
@@ -565,9 +565,9 @@ class Test_include(unittest.TestCase):
         self.assertEqual(action['args'][0].args, (('x', b('foo')), ('y', 3)))
         self.assertEqual(context.stack, before_stack)
         self.assertEqual(len(context._seen_files), 3)
-        self.assertTrue(fqn1 in context._seen_files)
-        self.assertTrue(fqn2 in context._seen_files)
-        self.assertTrue(fqn3 in context._seen_files)
+        self.assertIn(fqn1, context._seen_files)
+        self.assertIn(fqn2, context._seen_files)
+        self.assertIn(fqn3, context._seen_files)
 
 
 class Test_exclude(unittest.TestCase):
@@ -593,7 +593,7 @@ class Test_exclude(unittest.TestCase):
         self._callFUT(context)
         self.assertEqual(len(context.actions), 0)
         self.assertEqual(len(context._seen_files), 1)
-        self.assertTrue(fqn in context._seen_files)
+        self.assertIn(fqn, context._seen_files)
 
     def test_w_file_passed(self):
         from zope.configuration.config import ConfigurationMachine
@@ -604,7 +604,7 @@ class Test_exclude(unittest.TestCase):
         self._callFUT(context, 'simple.zcml')
         self.assertEqual(len(context.actions), 0)
         self.assertEqual(len(context._seen_files), 1)
-        self.assertTrue(fqn in context._seen_files)
+        self.assertIn(fqn, context._seen_files)
 
     def test_w_files_passed_and_package(self):
         from zope.configuration.config import ConfigurationMachine
@@ -616,9 +616,9 @@ class Test_exclude(unittest.TestCase):
         self._callFUT(context, package=samplepackage, files='baz*.zcml')
         self.assertEqual(len(context.actions), 0)
         self.assertEqual(len(context._seen_files), 3)
-        self.assertTrue(fqn1 in context._seen_files)
-        self.assertTrue(fqn2 in context._seen_files)
-        self.assertTrue(fqn3 in context._seen_files)
+        self.assertIn(fqn1, context._seen_files)
+        self.assertIn(fqn2, context._seen_files)
+        self.assertIn(fqn3, context._seen_files)
 
     def test_w_subpackage(self):
         from zope.configuration.config import ConfigurationMachine
@@ -633,7 +633,7 @@ class Test_exclude(unittest.TestCase):
         self.assertEqual(len(context._seen_files), 1)
         self.assertFalse(fqne_spam in context._seen_files)
         self.assertFalse(fqne_config in context._seen_files)
-        self.assertTrue(fqns_config in context._seen_files)
+        self.assertIn(fqns_config, context._seen_files)
 
 
 class Test_includeOverrides(unittest.TestCase):
@@ -687,7 +687,7 @@ class Test_includeOverrides(unittest.TestCase):
                          _packageFile(tests, '__init__.py'))
         self.assertEqual(context.stack, before_stack)
         self.assertEqual(len(context._seen_files), 1)
-        self.assertTrue(fqn in context._seen_files)
+        self.assertIn(fqn, context._seen_files)
 
 
 class Test_file(unittest.TestCase):


### PR DESCRIPTION
- Drop the Python < 2.7 compatibility shim from   d25ab5ed518eff905f4ea46c4194f5d30d21cf61.
- Use `assertRaises` as context manager everywhere.
- Fix up related assertions.
- Modernize `self.assertTrue(foo in bar)` -> `self.assertIn(foo, bar)`.
- Modernize `self.assertTrue(isinstance(foo, Bar))` -> `self.assertIsInstance(foo, Bar)`.