### PR TITLE
Make MessageID decode a bytes domain.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = src
+
+[report]
+exclude_lines =
+    pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,27 @@
 language: python
 sudo: false
 python:
-    - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
-    - 3.6
-    - pypy
-install:
-    - pip install .
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy-5.4.1
 script:
-    - python setup.py -q test -q
+  - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+
+after_success:
+  - coveralls
 notifications:
-    email: false
+  email: false
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install -U -e ".[test]"
+
+
+cache: pip
+
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Changes
 
 - Add support for Python 3.5 and 3.6.
 
+- Fix the ``domain`` of MessageID fields to be a native string.
+  Previously on Python 3 they were bytes, which meant that they
+  couldn't be used to find translation utilities registered by
+  zope.i18n. See `issue 17 <https://github.com/zopefoundation/zope.configuration/issues/17>`_.
+
 4.0.3 (2014-03-19)
 ------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .coveragerc
 
 recursive-include docs *.rst *.bat *.py Makefile
 recursive-include src *.zcml *.in

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ import os
 from setuptools import setup, find_packages
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
 def _modname(path, base, name=''):
     if path == base:
@@ -36,7 +37,7 @@ def alltests():
 
     class NullHandler(logging.Handler):
         level = 50
-        
+
         def emit(self, record):
             pass
 
@@ -56,10 +57,12 @@ def alltests():
                     suite.addTest(mod.test_suite())
     return suite
 
-TESTS_REQUIRE = []
+TESTS_REQUIRE = [
+    'zope.testrunner',
+]
 
 setup(name='zope.configuration',
-      version = '4.1.0.dev0',
+      version='4.1.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Configuration Markup Language (ZCML)',
@@ -68,8 +71,8 @@ setup(name='zope.configuration',
           + '\n\n' +
           read('CHANGES.rst')
           ),
-      keywords = "zope configuration zcml",
-      classifiers = [
+      keywords="zope configuration zcml",
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
@@ -95,16 +98,17 @@ setup(name='zope.configuration',
       namespace_packages=['zope'],
       extras_require={
         'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
-        'test': [],
+        'test': TESTS_REQUIRE,
         'testing': TESTS_REQUIRE + ['nose', 'coverage'],
       },
-      install_requires=['zope.i18nmessageid',
-                        'zope.interface',
-                        'zope.schema',
-                        'setuptools',
-                       ],
+      install_requires=[
+          'setuptools',
+          'zope.i18nmessageid',
+          'zope.interface',
+          'zope.schema',
+      ],
       include_package_data=True,
       zip_safe=False,
-      tests_require = TESTS_REQUIRE,
+      tests_require=TESTS_REQUIRE,
       test_suite='__main__.alltests',
-      )
+)

--- a/src/zope/configuration/fields.py
+++ b/src/zope/configuration/fields.py
@@ -15,6 +15,7 @@
 """
 import os
 import re
+import sys
 import warnings
 
 from zope.interface import implementer
@@ -158,6 +159,14 @@ class MessageID(Text):
                 "You did not specify an i18n translation domain for the "\
                 "'%s' field in %s" % (self.getName(), context.info.file )
                 )
+        if not isinstance(domain, str):
+            # IZopeConfigure specifies i18n_domain as a BytesLine, but that's
+            # wrong on Python 3, where the filesystem uses str, and hence
+            # zope.i18n registers ITranslationDomain utilities with str names.
+            # If we keep bytes, we can't find those utilities.
+            enc = sys.getfilesystemencoding() or sys.getdefaultencoding()
+            domain = domain.decode(enc)
+
         v = super(MessageID, self).fromUnicode(u)
 
         # Check whether there is an explicit message is specified

--- a/src/zope/configuration/tests/test_fields.py
+++ b/src/zope/configuration/tests/test_fields.py
@@ -34,7 +34,7 @@ class PythonIdentifierTests(unittest.TestCase, _ConformsToIFromUnicode):
     def _getTargetClass(self):
         from zope.configuration.fields import PythonIdentifier
         return PythonIdentifier
-    
+
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
@@ -69,7 +69,7 @@ class GlobalObjectTests(unittest.TestCase, _ConformsToIFromUnicode):
     def _getTargetClass(self):
         from zope.configuration.fields import GlobalObject
         return GlobalObject
-    
+
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
@@ -143,7 +143,7 @@ class GlobalInterfaceTests(unittest.TestCase, _ConformsToIFromUnicode):
     def _getTargetClass(self):
         from zope.configuration.fields import GlobalInterface
         return GlobalInterface
-    
+
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
@@ -157,7 +157,7 @@ class TokensTests(unittest.TestCase, _ConformsToIFromUnicode):
     def _getTargetClass(self):
         from zope.configuration.fields import Tokens
         return Tokens
-    
+
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
@@ -188,7 +188,7 @@ class PathTests(unittest.TestCase, _ConformsToIFromUnicode):
     def _getTargetClass(self):
         from zope.configuration.fields import Path
         return Path
-    
+
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
@@ -214,7 +214,7 @@ class BoolTests(unittest.TestCase, _ConformsToIFromUnicode):
     def _getTargetClass(self):
         from zope.configuration.fields import Bool
         return Bool
-    
+
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
@@ -244,7 +244,7 @@ class MessageIDTests(unittest.TestCase, _ConformsToIFromUnicode):
     def _getTargetClass(self):
         from zope.configuration.fields import MessageID
         return MessageID
-    
+
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
@@ -306,14 +306,13 @@ class MessageIDTests(unittest.TestCase, _ConformsToIFromUnicode):
         self.assertEqual(context.i18n_strings,
                          {'testing_domain': {'testing': [('test_file', 42)]}})
 
+    def test_domain_decodes_bytes(self):
+        mid = self._makeOne()
+        context = self._makeContext(domain=b'domain')
+        bound = mid.bind(context)
+        msgid = bound.fromUnicode(u'msgid')
+        self.assertIsInstance(msgid.domain, str)
+        self.assertEqual(msgid.domain, 'domain')
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(PythonIdentifierTests),
-        unittest.makeSuite(GlobalObjectTests),
-        unittest.makeSuite(GlobalInterfaceTests),
-        unittest.makeSuite(TokensTests),
-        unittest.makeSuite(PathTests),
-        unittest.makeSuite(BoolTests),
-        unittest.makeSuite(MessageIDTests),
-        ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,38 +1,31 @@
 [tox]
-envlist = 
+envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
 #   py27,py33,py34,py35,jython,pypy,coverage,docs
     py27,py33,py34,py35,py36,pypy,coverage,docs
 
 [testenv]
-# see https://github.com/zopefoundation/zope.configuration/issues/16 for
-# the reason we set usedevelop here
-usedevelop = true
 deps =
-    zope.event
-    zope.i18nmessageid
-    zope.interface
-    zope.schema
-commands = 
-    python setup.py -q test -q
+    .[test]
+commands =
+    zope-testrunner --test-path=src --all []
 
 [testenv:coverage]
 usedevelop = true
 basepython =
     python2.7
-commands = 
-    nosetests --with-xunit --with-xcoverage
+commands =
+    coverage run -m zope.testrunner --test-path=src --all
+	coverage report
 deps =
     {[testenv]deps}
-    nose
     coverage
-    nosexcover
 
 [testenv:docs]
 basepython =
     python2.7
-commands = 
+commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ basepython =
     python2.7
 commands =
     coverage run -m zope.testrunner --test-path=src --all
-	coverage report
+    coverage report
 deps =
     {[testenv]deps}
     coverage


### PR DESCRIPTION
Fixes #17.

Also use zope.testrunner to handle the namespace package issues.

Fixes #16.

Since we were in .travis.yml, enable coverage reporting and pip
caching.