### PR TITLE
Make ``GroupingContextDecorator`` stop shadowing builtins in ``__getattr__``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,13 @@ Changes
 
 - Drop support for ``python setup.py test``.
 
-- Fix resolving names from a Python 2 package whose `__init__.py` has
-  unicode elements in `__all__`.
+- Fix resolving names from a Python 2 package whose ``__init__.py`` has
+  unicode elements in ``__all__``.
+
+- Make ``GroupingContextDecorator`` stop shadowing builtins in its
+  ``__getattr__``. These were not intended as arguments to be used by
+  subclasses, and the signature caused confusion.
+
 
 4.1.0 (2017-04-26)
 ------------------

--- a/src/zope/configuration/config.py
+++ b/src/zope/configuration/config.py
@@ -386,7 +386,7 @@ class ConfigurationMachine(ConfigurationAdapterRegistry, ConfigurationContext):
                         reraise(ConfigurationExecutionError(t, v, info),
                                 None, tb)
                     finally:
-                       del t, v, tb
+                        del t, v, tb
 
         finally:
             if clear:
@@ -597,8 +597,7 @@ class GroupingContextDecorator(ConfigurationContext):
         for name, v in kw.items():
             setattr(self, name, v)
 
-    def __getattr__(self, name,
-                    getattr=getattr, setattr=setattr):
+    def __getattr__(self, name):
         v = getattr(self.context, name)
         # cache result in self
         setattr(self, name, v)
@@ -1039,4 +1038,3 @@ def _bootstrap(context):
             handler="zope.configuration.config.provides",
             schema="zope.configuration.config.IProvidesDirectiveInfo"
             )
-


### PR DESCRIPTION
These were not intended as arguments to be used by subclasses, and the signature caused confusion. Presumably this was done as an optimization, but in the absence of any benchmarks or even comments, it doesn't seem worth the confusion.