### PR TITLE
Add __all__ to all modules.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changes
   multiple leading dots. See `issue 41
   <https://github.com/zopefoundation/zope.configuration/issues/41>`_.
 
+- Add ``__all__`` to all modules listing the documented members of
+  the module. Note that this is currently a broad list and may be
+  reduced in the future.
+
 
 4.2.1 (2018-09-26)
 ------------------

--- a/src/zope/configuration/config.py
+++ b/src/zope/configuration/config.py
@@ -37,7 +37,36 @@ from zope.configuration._compat import reraise
 from zope.configuration._compat import string_types
 from zope.configuration._compat import text_type
 
-
+__all__ = [
+    'ConfigurationContext',
+    'ConfigurationAdapterRegistry',
+    'ConfigurationMachine',
+    'ConfigurationExecutionError',
+    'IStackItem',
+    'SimpleStackItem',
+    'RootStackItem',
+    'GroupingStackItem',
+    'ComplexStackItem',
+    'GroupingContextDecorator',
+    'DirectiveSchema',
+    'IDirectivesInfo',
+    'IDirectivesContext',
+    'DirectivesHandler',
+    'IDirectiveInfo',
+    'IFullInfo',
+    'IStandaloneDirectiveInfo',
+    'defineSimpleDirective',
+    'defineGroupingDirective',
+    'IComplexDirectiveContext',
+    'ComplexDirectiveDefinition',
+    'subdirective',
+    'IProvidesDirectiveInfo',
+    'provides',
+    'toargs',
+    'expand_action',
+    'resolveConflicts',
+    'ConfigurationConflictError',
+]
 
 zopens = 'http://namespaces.zope.org/zope'
 metans = 'http://namespaces.zope.org/meta'

--- a/src/zope/configuration/docutils.py
+++ b/src/zope/configuration/docutils.py
@@ -17,6 +17,11 @@ __docformat__ = 'restructuredtext'
 
 import re
 
+__all__ = [
+    'wrap',
+    'makeDocStructures',
+]
+
 para_sep = re.compile('\n{2,}')
 whitespace = re.compile('[ \t\n\r]+')
 
@@ -27,7 +32,7 @@ def wrap(text, width=78, indent=0):
 
     new_paras = []
     for par in paras:
-        words= filter(None, whitespace.split(par))
+        words = filter(None, whitespace.split(par))
 
         lines = []
         line = []

--- a/src/zope/configuration/exceptions.py
+++ b/src/zope/configuration/exceptions.py
@@ -14,6 +14,10 @@
 """Standard configuration errors
 """
 
+__all__ = [
+    'ConfigurationError',
+]
+
 class ConfigurationError(Exception):
     """There was an error in a configuration
     """

--- a/src/zope/configuration/fields.py
+++ b/src/zope/configuration/fields.py
@@ -32,6 +32,16 @@ from zope.schema.interfaces import InvalidValue
 from zope.configuration.exceptions import ConfigurationError
 from zope.configuration.interfaces import InvalidToken
 
+__all__ = [
+    'PythonIdentifier',
+    'GlobalObject',
+    'GlobalInterface',
+    'Tokens',
+    'Path',
+    'Bool',
+    'MessageID',
+]
+
 
 class PythonIdentifier(schema_PythonIdentifier):
     """

--- a/src/zope/configuration/interfaces.py
+++ b/src/zope/configuration/interfaces.py
@@ -17,6 +17,11 @@ from zope.interface import Interface
 from zope.schema import BytesLine
 from zope.schema.interfaces import ValidationError
 
+__all__ = [
+    'InvalidToken',
+    'IConfigurationContext',
+    'IGroupingContext',
+]
 
 class InvalidToken(ValidationError):
     """Invaid token in list."""

--- a/src/zope/configuration/name.py
+++ b/src/zope/configuration/name.py
@@ -17,6 +17,12 @@
 import os
 from types import ModuleType
 
+__all__ = [
+    'resolve',
+    'getNormalizedName',
+    'path',
+]
+
 def resolve(name, package='zopeproducts', _silly=('__doc__',), _globals={}):
     name = name.strip()
 

--- a/src/zope/configuration/xmlconfig.py
+++ b/src/zope/configuration/xmlconfig.py
@@ -45,6 +45,25 @@ from zope.configuration.zopeconfigure import IZopeConfigure
 from zope.configuration.zopeconfigure import ZopeConfigure
 from zope.configuration._compat import reraise
 
+__all__ = [
+    'ZopeXMLConfigurationError',
+    'ZopeSAXParseException',
+    'ParserInfo',
+    'ConfigurationHandler',
+    'processxmlfile',
+    'openInOrPlain',
+    'IInclude',
+    'include',
+    'exclude',
+    'includeOverrides',
+    'registerCommonDirectives',
+    'file',
+    'string',
+    'XMLConfig',
+    'xmlconfig',
+    'testxmlconfig',
+]
+
 logger = logging.getLogger("config")
 
 ZCML_NAMESPACE = "http://namespaces.zope.org/zcml"

--- a/src/zope/configuration/zopeconfigure.py
+++ b/src/zope/configuration/zopeconfigure.py
@@ -108,6 +108,10 @@ from zope.schema import BytesLine
 from zope.configuration.config import GroupingContextDecorator
 from zope.configuration.fields import GlobalObject
 
+__all__ = [
+    'IZopeConfigure',
+    'ZopeConfigure',
+]
 
 class IZopeConfigure(Interface):
     """The ``zope:configure`` Directive


### PR DESCRIPTION
The value replicates what is currently documented by Sphinx, which turns out to be *everything*. It's not clear though if that's all really meant to be consumed publicly.

In particular, there are things in `xmlconfig` that are marked as deprecated that are documented, and lots of things in `config` that are documented but look like internal details, and things that are "documented" but have no docstrings or sphinx docs. I would love to pare down the surface of the API documentation if anyone can help confirm/deny what's really meant to be public.

Fixes #38