### PR TITLE
Simplify exception chaining and nested exception error messages. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Simplify exception chaining and nested exception error messages.
+  See `issue 43 <https://github.com/zopefoundation/zope.configuration/issues/43>`_.
 
 
 4.2.2 (2018-09-27)

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -1162,16 +1162,15 @@ redefine our directives:
 .. doctest::
 
    >>> from zope.configuration.xmlconfig import string
-   >>> from zope.configuration.xmlconfig import ZopeXMLConfigurationError
-   >>> try:
-   ...    v = string(
+   >>> from zope.configuration.exceptions import ConfigurationError
+   >>> v = string(
    ...      '<text xmlns="http://sample.namespaces.zope.org/schema" name="x" />',
    ...      context)
-   ... except ZopeXMLConfigurationError as e:
-   ...   v = e
-   >>> print(v)
-   File "<string>", line 1.0
-       ConfigurationError: The directive ('http://sample.namespaces.zope.org/schema', 'text') cannot be used in this context
+   Traceback (most recent call last):
+   ...
+   zope.configuration.exceptions.ConfigurationError: The directive ('http://sample.namespaces.zope.org/schema', 'text') cannot be used in this context
+     File "<string>", line 1.0
+
 
 Let's see what happens if we declare duplicate fields:
 
@@ -1187,7 +1186,7 @@ Let's see what happens if we declare duplicate fields:
    ...      </schema>
    ...      ''',
    ...      context)
-   ... except ZopeXMLConfigurationError as e:
+   ... except ConfigurationError as e:
    ...   v = e
    >>> print(v)
    File "<string>", line 5.7-5.24

--- a/src/zope/configuration/config.py
+++ b/src/zope/configuration/config.py
@@ -764,23 +764,15 @@ class ConfigurationMachine(ConfigurationAdapterRegistry, ConfigurationContext):
                 info = action['info']
                 try:
                     callable(*args, **kw)
-                except BaseException as ex:
-                    try:
-                        if isinstance(ex, ConfigurationError):
-                            ex.append_details(info)
-                            raise
-                        if isinstance(ex, pass_through_exceptions):
-                            raise
-                        if not isinstance(ex, Exception):
-                            # BaseException
-                            raise
-
-                        # Wrap it up and raise.
-                        reraise(ConfigurationExecutionError(info, ex),
-                                None, sys.exc_info()[2])
-                    finally:
-                        del ex
-
+                except ConfigurationError as ex:
+                    ex.append_details(info)
+                    raise
+                except pass_through_exceptions:
+                    raise
+                except Exception:
+                    # Wrap it up and raise.
+                    reraise(ConfigurationExecutionError(info, sys.exc_info()[1]),
+                            None, sys.exc_info()[2])
         finally:
             if clear:
                 del self.actions[:]

--- a/src/zope/configuration/config.py
+++ b/src/zope/configuration/config.py
@@ -1685,15 +1685,16 @@ def toargs(context, schema, data):
             try:
                 args[str(name)] = field.fromUnicode(s)
             except ValidationError as v:
-                reraise(ConfigurationError("Invalid value for %r: %r" % (n, v)).add_details(v),
+                reraise(ConfigurationError("Invalid value for %r" % (n)).add_details(v),
                         None, sys.exc_info()[2])
         elif field.required:
             # if the default is valid, we can use that:
             default = field.default
             try:
                 field.validate(default)
-            except ValidationError:
-                raise ConfigurationError("Missing parameter:", n)
+            except ValidationError as v:
+                reraise(ConfigurationError("Missing parameter: %r" % (n,)).add_details(v),
+                        None, sys.exc_info()[2])
             args[str(name)] = default
 
     if data:

--- a/src/zope/configuration/config.py
+++ b/src/zope/configuration/config.py
@@ -74,10 +74,14 @@ testns = 'http://namespaces.zope.org/test'
 
 
 class ConfigurationContext(object):
-    """Mix-in that implements IConfigurationContext
+    """
+    Mix-in for implementing.
+    :class:`zope.configuration.interfaces.IConfigurationContext`.
 
-    Subclasses provide a ``package`` attribute and a ``basepath``
-    attribute.  If the base path is not None, relative paths are
+    Note that this class itself does not actually declare that it
+    implements that interface; the subclass must do that. In addition,
+    subclasses must provide a ``package`` attribute and a ``basepath``
+    attribute. If the base path is not None, relative paths are
     converted to absolute paths using the the base path. If the
     package is not none, relative imports are performed relative to
     the package.
@@ -91,33 +95,37 @@ class ConfigurationContext(object):
     attribute.
 
     The include path is appended to each action and is used when
-    resolving conflicts among actions.  Normally, only the a
+    resolving conflicts among actions. Normally, only the a
     ConfigurationMachine provides the actions attribute. Decorators
     simply use the actions of the context they decorate. The
-    ``includepath`` attribute is a tuple of names.  Each name is
+    ``includepath`` attribute is a tuple of names. Each name is
     typically the name of an included configuration file.
 
     The ``info`` attribute contains descriptive information helpful
-    when reporting errors.  If not set, it defaults to an empty string.
+    when reporting errors. If not set, it defaults to an empty string.
 
-    The actions attribute is a sequence of dictionaries where each dictionary
-    has the following keys:
+    The actions attribute is a sequence of dictionaries where each
+    dictionary has the following keys:
 
-      - ``discriminator``, a value that identifies the action. Two actions
-        that have the same (non None) discriminator conflict.
+        - ``discriminator``, a value that identifies the action. Two
+          actions that have the same (non None) discriminator
+          conflict.
 
-      - ``callable``, an object that is called to execute the action,
+        - ``callable``, an object that is called to execute the
+          action,
 
-      - ``args``, positional arguments for the action
+        - ``args``, positional arguments for the action
 
-      - ``kw``, keyword arguments for the action
+        - ``kw``, keyword arguments for the action
 
-      - ``includepath``, a tuple of include file names (defaults to ())
+        - ``includepath``, a tuple of include file names (defaults to
+          ())
 
-      - ``info``, an object that has descriptive information about
-        the action (defaults to '')
-
+        - ``info``, an object that has descriptive information about
+          the action (defaults to '')
     """
+
+    # pylint:disable=no-member
 
     def __init__(self):
         super(ConfigurationContext, self).__init__()
@@ -666,8 +674,8 @@ class ConfigurationMachine(ConfigurationAdapterRegistry, ConfigurationContext):
     info = ''
 
     #: These `Exception` subclasses are allowed to be raised from `execute_actions`
-    #: without being re-wrapped into a `ConfigurationExecutionError`. (`BaseException`
-    #: instances are never wrapped.)
+    #: without being re-wrapped into a `~.ConfigurationError`. (`BaseException`
+    #: and other `~.ConfigurationError` instances are never wrapped.)
     #:
     #: Users of instances of this class may modify this before calling `execute_actions`
     #: if they need to propagate specific exceptions.
@@ -727,9 +735,8 @@ class ConfigurationMachine(ConfigurationAdapterRegistry, ConfigurationContext):
             [('f', (1,), {}), ('f', (2,), {})]
 
         If the action raises an error, we convert it to a
-        `ConfigurationExecutionError`.
+        `~.ConfigurationError`.
 
-            >>> from zope.configuration.config import ConfigurationExecutionError
             >>> output = []
             >>> def bad():
             ...    bad.xxx
@@ -751,7 +758,7 @@ class ConfigurationMachine(ConfigurationAdapterRegistry, ConfigurationContext):
             >>> output
             [('f', (1,), {}), ('f', (2,), {})]
 
-        If the exception was already a `ConfigurationError`, it is raised
+        If the exception was already a `~.ConfigurationError`, it is raised
         as-is with the action's ``info`` added.
 
             >>> def bad():
@@ -1808,9 +1815,10 @@ def resolveConflicts(actions):
 class ConfigurationConflictError(ConfigurationError):
 
     def __init__(self, conflicts):
+        super(ConfigurationConflictError, self).__init__()
         self._conflicts = conflicts
 
-    def __str__(self): #pragma NO COVER
+    def _with_details(self, opening, detail_formatter):
         r = ["Conflicting configuration actions"]
         for discriminator, infos in sorted(self._conflicts.items()):
             r.append("  For: %s" % (discriminator, ))
@@ -1818,7 +1826,8 @@ class ConfigurationConflictError(ConfigurationError):
                 for line in text_type(info).rstrip().split(u'\n'):
                     r.append(u"    " + line)
 
-        return "\n".join(r)
+        opening = "\n".join(r)
+        return super(ConfigurationConflictError, self)._with_details(opening, detail_formatter)
 
 
 ##############################################################################

--- a/src/zope/configuration/exceptions.py
+++ b/src/zope/configuration/exceptions.py
@@ -14,6 +14,8 @@
 """Standard configuration errors
 """
 
+import traceback
+
 __all__ = [
     'ConfigurationError',
 ]
@@ -21,3 +23,44 @@ __all__ = [
 class ConfigurationError(Exception):
     """There was an error in a configuration
     """
+
+    # A list of strings or things that can be converted to strings,
+    # added by append_details as we walk back up the call/include stack.
+    _details = ()
+
+    def append_details(self, info):
+        if isinstance(info, BaseException):
+            info = traceback.format_exception_only(type(info), info)
+            # Trim trailing newline
+            info[-1] = info[-1].rstrip()
+            self._details += tuple(info)
+        else:
+            self._details += (info,)
+        return self
+
+    def __str__(self):
+        s = super(ConfigurationError, self).__str__()
+        for i in self._details:
+            s += '\n    ' + str(i)
+        return s
+
+    def __repr__(self):
+        s = super(ConfigurationError, self).__repr__()
+        for i in self._details:
+            s += '\n    ' + repr(i)
+        return s
+
+
+class ConfigurationWrapperError(ConfigurationError):
+
+    USE_INFO_REPR = False
+
+    def __init__(self, info, exception):
+        super(ConfigurationWrapperError, self).__init__(repr(info) if self.USE_INFO_REPR else info)
+        self.append_details(exception)
+
+        # This stuff is undocumented and not used but we store
+        # for backwards compatibility
+        self.info = info
+        self.etype = type(exception)
+        self.evalue = exception

--- a/src/zope/configuration/tests/test_config.py
+++ b/src/zope/configuration/tests/test_config.py
@@ -1974,6 +1974,14 @@ class Test_resolveConflicts(unittest.TestCase):
             "For: ('a', 1)\n    conflict!\n    conflict2!",
             str(exc.exception))
 
+        exc.exception.add_details('a detail')
+
+        self.assertEqual(
+            "Conflicting configuration actions\n  "
+            "For: ('a', 1)\n    conflict!\n    conflict2!\n"
+            "    a detail",
+            str(exc.exception))
+
     def test_wo_discriminators_final_sorting_order(self):
         from zope.configuration.config import expand_action
         def _a():

--- a/src/zope/configuration/tests/test_config.py
+++ b/src/zope/configuration/tests/test_config.py
@@ -1810,7 +1810,7 @@ class Test_toargs(unittest.TestCase):
         with self.assertRaises(ConfigurationError) as exc:
             self._callFUT(context, ISchema, {'count': '-1'})
         self.assertEqual(exc.exception.args,
-                         ('Invalid value for', 'count', '(-1, 0)'))
+                         ("Invalid value for 'count': TooSmall(-1, 0)",))
 
 
 class Test_expand_action(unittest.TestCase):

--- a/src/zope/configuration/tests/test_config.py
+++ b/src/zope/configuration/tests/test_config.py
@@ -1789,7 +1789,18 @@ class Test_toargs(unittest.TestCase):
         with self.assertRaises(ConfigurationError) as exc:
             self._callFUT(context, ISchema, {})
         self.assertEqual(exc.exception.args,
-                         ('Missing parameter:', 'no_default'))
+                         ("Missing parameter: 'no_default'",))
+
+        # It includes the details of any validation failure;
+        # The rendering of the nested exception varies by Python version,
+        # sadly.
+        exception_str = str(exc.exception)
+        self.assertTrue(exception_str.startswith(
+            "Missing parameter: 'no_default'\n"
+        ), exception_str)
+        self.assertTrue(exception_str.endswith(
+            "RequiredMissing: no_default"
+        ), exception_str)
 
     def test_w_field_missing_but_default(self):
         from zope.interface import Interface
@@ -1810,8 +1821,15 @@ class Test_toargs(unittest.TestCase):
         with self.assertRaises(ConfigurationError) as exc:
             self._callFUT(context, ISchema, {'count': '-1'})
         self.assertEqual(exc.exception.args,
-                         ("Invalid value for 'count': TooSmall(-1, 0)",))
+                         ("Invalid value for 'count'",))
 
+        exception_str = str(exc.exception)
+        self.assertTrue(exception_str.startswith(
+            "Invalid value for 'count'\n"
+        ), exception_str)
+        self.assertTrue(exception_str.endswith(
+            "TooSmall: (-1, 0)"
+        ), exception_str)
 
 class Test_expand_action(unittest.TestCase):
 

--- a/src/zope/configuration/tests/test_config.py
+++ b/src/zope/configuration/tests/test_config.py
@@ -1823,13 +1823,14 @@ class Test_toargs(unittest.TestCase):
         self.assertEqual(exc.exception.args,
                          ("Invalid value for 'count'",))
 
-        exception_str = str(exc.exception)
-        self.assertTrue(exception_str.startswith(
-            "Invalid value for 'count'\n"
-        ), exception_str)
-        self.assertTrue(exception_str.endswith(
-            "TooSmall: (-1, 0)"
-        ), exception_str)
+        for meth in str, repr:
+            exception_str = meth(exc.exception)
+            self.assertIn(
+                "Invalid value for",
+                exception_str)
+            self.assertIn(
+                "TooSmall: (-1, 0)",
+                exception_str)
 
 class Test_expand_action(unittest.TestCase):
 

--- a/src/zope/configuration/tests/test_xmlconfig.py
+++ b/src/zope/configuration/tests/test_xmlconfig.py
@@ -58,16 +58,16 @@ class ZopeSAXParseExceptionTests(unittest.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def test___str___not_a_sax_error(self):
-        zxce = self._makeOne(Exception('Not a SAX error'))
+        zxce = self._makeOne("info", Exception('Not a SAX error'))
         self.assertEqual(
             str(zxce),
-            "Not a SAX error\n    Exception: Not a SAX error")
+            "info\n    Exception: Not a SAX error")
 
     def test___str___w_a_sax_error(self):
-        zxce = self._makeOne(Exception('filename.xml:24:32:WAAA'))
+        zxce = self._makeOne("info", Exception('filename.xml:24:32:WAAA'))
         self.assertEqual(
             str(zxce),
-            'File "filename.xml", line 24.32, WAAA\n    Exception: filename.xml:24:32:WAAA')
+            'info\n    Exception: filename.xml:24:32:WAAA')
 
 
 class ParserInfoTests(unittest.TestCase):
@@ -395,7 +395,7 @@ class Test_processxmlfile(unittest.TestCase):
         registerCommonDirectives(context)
         with self.assertRaises(ZopeSAXParseException) as exc:
             self._callFUT(StringIO(), context)
-        self.assertEqual(str(exc.exception._v),
+        self.assertEqual(str(exc.exception.evalue),
                          '<string>:1:0: no element found')
 
     def test_w_valid_xml_fp(self):

--- a/src/zope/configuration/tests/test_xmlconfig.py
+++ b/src/zope/configuration/tests/test_xmlconfig.py
@@ -29,6 +29,7 @@ BVALUE = u'bvalue'
 # pylint:disable=protected-access
 
 class ZopeXMLConfigurationErrorTests(unittest.TestCase):
+    maxDiff = None
 
     def _getTargetClass(self):
         from zope.configuration.xmlconfig import ZopeXMLConfigurationError
@@ -38,11 +39,16 @@ class ZopeXMLConfigurationErrorTests(unittest.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def test___str___uses_repr_of_info(self):
-        zxce = self._makeOne('info', Exception, 'value')
-        self.assertEqual(str(zxce), "'info'\n    Exception: value")
+        zxce = self._makeOne('info', Exception('value'))
+        self.assertEqual(
+            str(zxce),
+            "'info'\n    Exception: value"
+        )
+
 
 
 class ZopeSAXParseExceptionTests(unittest.TestCase):
+    maxDiff = None
 
     def _getTargetClass(self):
         from zope.configuration.xmlconfig import ZopeSAXParseException
@@ -53,11 +59,15 @@ class ZopeSAXParseExceptionTests(unittest.TestCase):
 
     def test___str___not_a_sax_error(self):
         zxce = self._makeOne(Exception('Not a SAX error'))
-        self.assertEqual(str(zxce), "Not a SAX error")
+        self.assertEqual(
+            str(zxce),
+            "Not a SAX error\n    Exception: Not a SAX error")
 
     def test___str___w_a_sax_error(self):
         zxce = self._makeOne(Exception('filename.xml:24:32:WAAA'))
-        self.assertEqual(str(zxce), 'File "filename.xml", line 24.32, WAAA')
+        self.assertEqual(
+            str(zxce),
+            'File "filename.xml", line 24.32, WAAA\n    Exception: filename.xml:24:32:WAAA')
 
 
 class ParserInfoTests(unittest.TestCase):

--- a/src/zope/configuration/xmlconfig.py
+++ b/src/zope/configuration/xmlconfig.py
@@ -90,29 +90,17 @@ class ZopeXMLConfigurationError(ConfigurationWrapperError):
 
 class ZopeSAXParseException(ConfigurationWrapperError):
     """
-    Sax Parser errors, reformatted in an emacs friendly way.
+    Sax Parser errors as a ConfigurationError.
 
     Example
 
         >>> from zope.configuration.xmlconfig import ZopeSAXParseException
-        >>> v = ZopeSAXParseException(Exception("foo.xml:12:3:Not well formed"))
+        >>> v = ZopeSAXParseException("info", Exception("foo.xml:12:3:Not well formed"))
         >>> print(v)
-        File "foo.xml", line 12.3, Not well formed
+        info
             Exception: foo.xml:12:3:Not well formed
     """
 
-    def __init__(self, exception):
-        s = tuple(str(exception).split(':'))
-        if len(s) == 4:
-            info = 'File "%s", line %s.%s, %s' % s
-        else:
-            info = str(exception)
-        super(ZopeSAXParseException, self).__init__(info, exception)
-
-    @property
-    def _v(self):
-        # BWC for testing only
-        return self.evalue
 
 class ParserInfo(object):
     r"""
@@ -418,7 +406,7 @@ def processxmlfile(file, context, testing=False):
     try:
         parser.parse(src)
     except SAXParseException:
-        reraise(ZopeSAXParseException(sys.exc_info()[1]),
+        reraise(ZopeSAXParseException(src, sys.exc_info()[1]),
                 None, sys.exc_info()[2])
 
 

--- a/src/zope/configuration/xmlconfig.py
+++ b/src/zope/configuration/xmlconfig.py
@@ -228,7 +228,7 @@ class ConfigurationHandler(ContentHandler):
         if self.testing:
             raise
         if isinstance(ex, ConfigurationError):
-            ex.append_details(repr(info))
+            ex.add_details(repr(info))
             raise
 
         exc = ZopeXMLConfigurationError(info, ex)
@@ -406,7 +406,7 @@ def processxmlfile(file, context, testing=False):
     try:
         parser.parse(src)
     except SAXParseException:
-        reraise(ZopeSAXParseException(src, sys.exc_info()[1]),
+        reraise(ZopeSAXParseException(file, sys.exc_info()[1]),
                 None, sys.exc_info()[2])
 
 

--- a/src/zope/configuration/xmlconfig.py
+++ b/src/zope/configuration/xmlconfig.py
@@ -242,10 +242,9 @@ class ConfigurationHandler(ContentHandler):
         if isinstance(ex, ConfigurationError):
             ex.append_details(repr(info))
             raise
-        else:
-            exc = ZopeXMLConfigurationError(info, ex)
-            reraise(exc,
-                    None, sys.exc_info()[2])
+
+        exc = ZopeXMLConfigurationError(info, ex)
+        reraise(exc, None, sys.exc_info()[2])
 
     def startElementNS(self, name, qname, attrs):
         if self.ignore_depth:

--- a/src/zope/configuration/xmlconfig.py
+++ b/src/zope/configuration/xmlconfig.py
@@ -40,14 +40,13 @@ from zope.configuration.config import GroupingContextDecorator
 from zope.configuration.config import GroupingStackItem
 from zope.configuration.config import resolveConflicts
 from zope.configuration.exceptions import ConfigurationError
+from zope.configuration.exceptions import ConfigurationWrapperError
 from zope.configuration.fields import GlobalObject
 from zope.configuration.zopeconfigure import IZopeConfigure
 from zope.configuration.zopeconfigure import ZopeConfigure
 from zope.configuration._compat import reraise
 
 __all__ = [
-    'ZopeXMLConfigurationError',
-    'ZopeSAXParseException',
     'ParserInfo',
     'ConfigurationHandler',
     'processxmlfile',
@@ -70,7 +69,7 @@ ZCML_NAMESPACE = "http://namespaces.zope.org/zcml"
 ZCML_CONDITION = (ZCML_NAMESPACE, u"condition")
 
 
-class ZopeXMLConfigurationError(ConfigurationError):
+class ZopeXMLConfigurationError(ConfigurationWrapperError):
     """
     Zope XML Configuration error
 
@@ -80,41 +79,40 @@ class ZopeXMLConfigurationError(ConfigurationError):
     Example
 
         >>> from zope.configuration.xmlconfig import ZopeXMLConfigurationError
-        >>> v = ZopeXMLConfigurationError("blah", AttributeError, "xxx")
+        >>> v = ZopeXMLConfigurationError("blah", AttributeError("xxx"))
         >>> print(v)
         'blah'
             AttributeError: xxx
     """
-    def __init__(self, info, etype, evalue):
-        self.info, self.etype, self.evalue = info, etype, evalue
 
-    def __str__(self):
-        # Only use the repr of the info. This is because we expect to
-        # get a parse info and we only want the location information.
-        return "%s\n    %s: %s" % (
-            repr(self.info), self.etype.__name__, self.evalue)
+    USE_INFO_REPR = True
 
-class ZopeSAXParseException(ConfigurationError):
+
+class ZopeSAXParseException(ConfigurationWrapperError):
     """
     Sax Parser errors, reformatted in an emacs friendly way.
 
     Example
 
         >>> from zope.configuration.xmlconfig import ZopeSAXParseException
-        >>> v = ZopeSAXParseException("foo.xml:12:3:Not well formed")
+        >>> v = ZopeSAXParseException(Exception("foo.xml:12:3:Not well formed"))
         >>> print(v)
         File "foo.xml", line 12.3, Not well formed
+            Exception: foo.xml:12:3:Not well formed
     """
-    def __init__(self, v):
-        self._v = v
 
-    def __str__(self):
-        v = self._v
-        s = tuple(str(v).split(':'))
+    def __init__(self, exception):
+        s = tuple(str(exception).split(':'))
         if len(s) == 4:
-            return 'File "%s", line %s.%s, %s' % s
+            info = 'File "%s", line %s.%s, %s' % s
         else:
-            return str(v)
+            info = str(exception)
+        super(ZopeSAXParseException, self).__init__(info, exception)
+
+    @property
+    def _v(self):
+        # BWC for testing only
+        return self.evalue
 
 class ParserInfo(object):
     r"""
@@ -238,6 +236,17 @@ class ConfigurationHandler(ContentHandler):
     def characters(self, text):
         self.context.getInfo().characters(text)
 
+    def _handle_exception(self, ex, info):
+        if self.testing:
+            raise
+        if isinstance(ex, ConfigurationError):
+            ex.append_details(repr(info))
+            raise
+        else:
+            exc = ZopeXMLConfigurationError(info, ex)
+            reraise(exc,
+                    None, sys.exc_info()[2])
+
     def startElementNS(self, name, qname, attrs):
         if self.ignore_depth:
             self.ignore_depth += 1
@@ -268,13 +277,8 @@ class ConfigurationHandler(ContentHandler):
 
         try:
             self.context.begin(name, data, info)
-        except Exception:
-            if self.testing:
-                raise
-            reraise(ZopeXMLConfigurationError(info,
-                                              sys.exc_info()[0],
-                                              sys.exc_info()[1]),
-                    None, sys.exc_info()[2])
+        except Exception as ex:
+            self._handle_exception(ex, info)
 
         self.context.setInfo(info)
 
@@ -398,13 +402,8 @@ class ConfigurationHandler(ContentHandler):
 
         try:
             self.context.end()
-        except Exception:
-            if self.testing:
-                raise
-            reraise(ZopeXMLConfigurationError(info,
-                                              sys.exc_info()[0],
-                                              sys.exc_info()[1]),
-                    None, sys.exc_info()[2])
+        except Exception as ex:
+            self._handle_exception(ex, info)
 
 
 def processxmlfile(file, context, testing=False):


### PR DESCRIPTION
(Based on #40 since it touches many of the same things.)

Fixes #43

Given a/b/c/d.zcml included in that order with an error in d.zcml, previously executing `python -c "from zope.configuration.xmlconfig import file; file('/tmp/a.zcml')"` would get this:

```
Traceback (most recent call last):
   ...
    raise InvalidDottedName(value).with_field_and_value(self, value)
zope.schema.interfaces.InvalidDottedName: invalid dotted name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
   ...
    raise InvalidDottedName(value).with_field_and_value(self, value)
zope.configuration.exceptions.ConfigurationError: ('Invalid value for', 'package', 'invalid dotted name')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
   ...
    raise InvalidDottedName(value).with_field_and_value(self, value)
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/tmp/d.zcml", line 2.4-2.58
    ConfigurationError: ('Invalid value for', 'package', 'invalid dotted name')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
   ...
    raise InvalidDottedName(value).with_field_and_value(self, value)
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/tmp/c.zcml", line 2.4-2.29
    ZopeXMLConfigurationError: File "/tmp/d.zcml", line 2.4-2.58
    ConfigurationError: ('Invalid value for', 'package', 'invalid dotted name')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
   ...
    raise InvalidDottedName(value).with_field_and_value(self, value)
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/tmp/b.zcml", line 2.4-2.29
    ZopeXMLConfigurationError: File "/tmp/c.zcml", line 2.4-2.29
    ZopeXMLConfigurationError: File "/tmp/d.zcml", line 2.4-2.58
    ConfigurationError: ('Invalid value for', 'package', 'invalid dotted name')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  ...
    raise InvalidDottedName(value).with_field_and_value(self, value)
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/tmp/a.zcml", line 2.4-2.29
    ZopeXMLConfigurationError: File "/tmp/b.zcml", line 2.4-2.29
    ZopeXMLConfigurationError: File "/tmp/c.zcml", line 2.4-2.29
    ZopeXMLConfigurationError: File "/tmp/d.zcml", line 2.4-2.58
    ConfigurationError: ('Invalid value for', 'package', 'invalid dotted name')
```

Now we get the simpler:

```
Traceback (most recent call last):
  ...
  File "/Users/jmadden/Projects/GithubSources/zope.schema/src/zope/schema/_field.py", line 670, in _validate
    raise InvalidDottedName(value).with_field_and_value(self, value)
zope.schema.interfaces.InvalidDottedName: invalid dotted name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  ...
    raise InvalidDottedName(value).with_field_and_value(self, value)
zope.configuration.exceptions.ConfigurationError: Invalid value for 'package': InvalidDottedName('invalid dotted name')
    zope.schema.interfaces.InvalidDottedName: invalid dotted name
    File "/tmp/d.zcml", line 2.4-2.58
    File "/tmp/c.zcml", line 2.4-2.29
    File "/tmp/b.zcml", line 2.4-2.29
    File "/tmp/a.zcml", line 2.4-2.29
```

Yes, there's still a bit of repetition in that final case, but that seems OK to me?

This changed the constructors of two of the internal exceptions, but nobody should have been constructing those things anyway, right? 

Looking for feedback.

WIP because I need to do some tweaks for coverage.

 /cc @mgedmin 