### PR TITLE
Do not break when running the tests from a wheel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not break when running the tests from a wheel.
 
 
 4.3.0 (2018-10-01)

--- a/src/zope/configuration/tests/test_docs.py
+++ b/src/zope/configuration/tests/test_docs.py
@@ -54,8 +54,14 @@ def test_suite():
         prev, here = here, os.path.dirname(here)
         if here == prev:
             # Let's avoid infinite loops at root
-            print('tests_doc.py: WARNING could not find setup.py -->'
-                  ' omitting documentation tests.')  # pragma: no cover
+            class SkippedDocTests(unittest.TestCase):  # pragma: no cover
+
+                @unittest.skip('Could not find setup.py')
+                def test_docs(self):
+                    pass
+
+            suite.addTest(
+                unittest.makeSuite(SkippedDocTests))  # pragma: no cover
             return suite  # pragma: no cover
 
     docs = os.path.join(here, 'docs')

--- a/src/zope/configuration/tests/test_docs.py
+++ b/src/zope/configuration/tests/test_docs.py
@@ -20,7 +20,6 @@ from __future__ import division
 from __future__ import print_function
 
 import re
-import sys
 import os.path
 import unittest
 import doctest
@@ -49,12 +48,15 @@ optionflags = (
 )
 
 def test_suite():
+    suite = unittest.TestSuite()
     here = os.path.dirname(os.path.abspath(__file__))
     while not os.path.exists(os.path.join(here, 'setup.py')):
         prev, here = here, os.path.dirname(here)
         if here == prev:
             # Let's avoid infinite loops at root
-            raise AssertionError('could not find my setup.py')
+            print('tests_doc.py: WARNING could not find setup.py -->'
+                  ' omitting documentation tests.')  # pragma: no cover
+            return suite  # pragma: no cover
 
     docs = os.path.join(here, 'docs')
     api_docs = os.path.join(docs, 'api')
@@ -89,7 +91,6 @@ def test_suite():
     m += manuel.codeblock.Manuel()
     m += manuel.capture.Manuel()
 
-    suite = unittest.TestSuite()
     suite.addTest(
         manuel.testing.TestSuite(
             m,

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ basepython =
     python3.6
 commands =
     coverage run -m zope.testrunner --test-path=src --all
-    coverage report --fail-under=100
+    coverage report --show-missing --skip-covered --fail-under=100
 deps =
     {[testenv]deps}
     coverage


### PR DESCRIPTION
The wheel does neither include `setup.py` nor the `docs` dir.
So omit the documentation tests when no `setup.py` can be found.
This should fix the tests in ZTK, see zopefoundation/zopetoolkit#27.