### PR TITLE
Avoid creating reference cycles through tracebacks in reraise

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid creating reference cycles through tracebacks in ``reraise`` (change
+  imported from ``six``).
 
 
 4.4.0 (2020-03-22)

--- a/src/zope/configuration/_compat.py
+++ b/src/zope/configuration/_compat.py
@@ -24,11 +24,15 @@ if PY3: # pragma: no cover
 
     # borrowed from 'six'
     def reraise(tp, value, tb=None):
-        if value is None:
-            value = tp
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
+        try:
+            if value is None:
+                value = tp
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
 
 else: # pragma: no cover
 
@@ -40,7 +44,10 @@ else: # pragma: no cover
     # borrowed from 'six'
     exec("""\
 def reraise(tp, value, tb=None):
-    raise tp, value, tb
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
 """)
 
 


### PR DESCRIPTION
This code was originally copied from ``six``; this brings it up to date
with the changes in 1.11.0.