### PR TITLE
Fix tests when running from a distribution.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 5.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix tests when running from a distribution.
 
 
 5.0 (2023-05-04)

--- a/setup.py
+++ b/setup.py
@@ -86,5 +86,4 @@ setup(name='zope.configuration',
       ],
       include_package_data=True,
       zip_safe=False,
-      tests_require=TESTS_REQUIRE,
       )

--- a/setup.py
+++ b/setup.py
@@ -28,16 +28,6 @@ def read(*rnames):
         return f.read()
 
 
-TESTS_REQUIRE = [
-    'manuel',
-    # We test the specific exceptions raised, which
-    # change from version to version, and we need the behaviour
-    # in DottedName that allows underscores.
-    'zope.schema >= 4.9.0',
-    'zope.testing',
-    'zope.testrunner',
-]
-
 setup(name='zope.configuration',
       version='5.1.dev0',
       author='Zope Foundation and Contributors',
@@ -76,7 +66,7 @@ setup(name='zope.configuration',
       python_requires='>=3.7',
       extras_require={
           'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
-          'test': TESTS_REQUIRE,
+          'test': ['zope.testing', 'zope.testrunner']
       },
       install_requires=[
           'setuptools',

--- a/src/zope/configuration/tests/test_docs.py
+++ b/src/zope/configuration/tests/test_docs.py
@@ -34,39 +34,7 @@ optionflags = (
 
 
 def test_suite():
-    # zope.testrunner
     suite = unittest.TestSuite()
-    here = os.path.dirname(os.path.abspath(__file__))
-    while not os.path.exists(os.path.join(here, 'setup.py')):
-        prev, here = here, os.path.dirname(here)
-        if here == prev:
-            # Let's avoid infinite loops at root
-            class SkippedDocTests(unittest.TestCase):  # pragma: no cover
-
-                @unittest.skip('Could not find setup.py')
-                def test_docs(self):
-                    pass
-
-            suite.addTest(
-                unittest.defaultTestLoader.loadTestsFromTestCase(
-                    SkippedDocTests))  # pragma: no cover
-            return suite  # pragma: no cover
-
-    docs = os.path.join(here, 'docs')
-    api_docs = os.path.join(docs, 'api')
-
-    doc_files_to_test = (
-        'narr.rst',
-    )
-
-    api_files_to_test = (
-        'config.rst',
-        'docutils.rst',
-        'fields.rst',
-        'xmlconfig.rst',
-    )
-
-    # Plain doctest suites
     api_to_test = (
         'config',
         'docutils',
@@ -75,21 +43,6 @@ def test_suite():
         'name',
         'xmlconfig',
         'zopeconfigure',
-    )
-
-    paths = [os.path.join(docs, f) for f in doc_files_to_test]
-    paths += [os.path.join(api_docs, f) for f in api_files_to_test]
-
-    m = manuel.ignore.Manuel()
-    m += manuel.doctest.Manuel(optionflags=optionflags)
-    m += manuel.codeblock.Manuel()
-    m += manuel.capture.Manuel()
-
-    suite.addTest(
-        manuel.testing.TestSuite(
-            m,
-            *paths
-        )
     )
 
     for mod_name in api_to_test:
@@ -102,8 +55,3 @@ def test_suite():
         )
 
     return suite
-
-
-def load_tests(loader, standard_tests, pattern):
-    # Pure unittest protocol.
-    return test_suite()

--- a/src/zope/configuration/tests/test_docs.py
+++ b/src/zope/configuration/tests/test_docs.py
@@ -16,14 +16,7 @@ Tests for the documentation.
 """
 
 import doctest
-import os.path
 import unittest
-
-import manuel.capture
-import manuel.codeblock
-import manuel.doctest
-import manuel.ignore
-import manuel.testing
 
 
 optionflags = (


### PR DESCRIPTION
Either the tests are run by Sphinx or they do not contain any tests.

Note: The docs directory is not part of the wheel (as well as the `setup.py`). If there is any `setup.py` in the path above the where the wheel is installed it was found.