### PR TITLE
Add support for checking environment variables in zcml conditions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changes
 6.0 (unreleased)
 ----------------
 
+- Add support for checking environment variables in zcml conditions.
+  Use ``envvar`` or ``not-envvar``.
+  ``not-envvar`` is true when the variable is not set, is empty, or is one of the usual 'falsy' values like '0'.
+
 - Drop support for Python 3.7.
 
 - Add support for Python 3.12.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changes
 
 - Add support for checking environment variables in zcml conditions.
   Use ``envvar`` or ``not-envvar``.
-  ``not-envvar`` is true when the variable is not set, is empty, or is one of the usual 'falsy' values like '0'.
+  ``not-envvar`` is true when the variable is not set, is empty, or has one of the usual 'false' values like '0'.
 
 - Drop support for Python 3.7.
 

--- a/src/zope/configuration/config.py
+++ b/src/zope/configuration/config.py
@@ -586,7 +586,7 @@ class ConfigurationContext:
         value = os.getenv(envvar)
         if not value:
             return False
-        return value not in ('0', 'false', 'no', 'f', 'n')
+        return value.lower() not in ('0', 'false', 'no', 'f', 'n')
 
 
 class ConfigurationAdapterRegistry:

--- a/src/zope/configuration/config.py
+++ b/src/zope/configuration/config.py
@@ -544,6 +544,50 @@ class ConfigurationContext:
         """
         self._features.add(feature)
 
+    def hasEnvironmentVariable(self, envvar):
+        """
+        Check whether an environment variable is set to a "truthy" value.
+
+        Examples:
+
+            >>> from zope.configuration.config import ConfigurationContext
+            >>> c = ConfigurationContext()
+            >>> c.hasEnvironmentVariable('SAMPLE_ZOPE_ENV_VAR')
+            False
+
+        An empty environment variable is false.
+
+            >>> try:
+            ...     os.environ['SAMPLE_ZOPE_ENV_VAR'] = ''
+            ...     c.hasEnvironmentVariable('SAMPLE_ZOPE_ENV_VAR')
+            ... finally:
+            ...     del os.environ['SAMPLE_ZOPE_ENV_VAR']
+            False
+
+        A "falsy" environment variable is false.
+
+            >>> try:
+            ...     os.environ['SAMPLE_ZOPE_ENV_VAR'] = '0'
+            ...     c.hasEnvironmentVariable('SAMPLE_ZOPE_ENV_VAR')
+            ... finally:
+            ...     del os.environ['SAMPLE_ZOPE_ENV_VAR']
+            False
+
+        Other values of the environment variable are true.
+
+            >>> try:
+            ...     os.environ['SAMPLE_ZOPE_ENV_VAR'] = '1'
+            ...     c.hasEnvironmentVariable('SAMPLE_ZOPE_ENV_VAR')
+            ... finally:
+            ...     del os.environ['SAMPLE_ZOPE_ENV_VAR']
+            True
+
+        """
+        value = os.getenv(envvar)
+        if not value:
+            return False
+        return value not in ('0', 'false', 'no', 'f', 'n')
+
 
 class ConfigurationAdapterRegistry:
     """

--- a/src/zope/configuration/xmlconfig.py
+++ b/src/zope/configuration/xmlconfig.py
@@ -372,7 +372,8 @@ class ConfigurationHandler(ContentHandler):
             >>> c.evaluateCondition("envvar x y")
             Traceback (most recent call last):
               ...
-            ValueError: Only one environment variable name allowed: 'envvar x y'
+            ValueError: Only one environment variable name allowed: \
+            'envvar x y'
 
             >>> c.evaluateCondition("envvar")
             Traceback (most recent call last):

--- a/src/zope/configuration/xmlconfig.py
+++ b/src/zope/configuration/xmlconfig.py
@@ -373,6 +373,23 @@ class ConfigurationHandler(ContentHandler):
                 return installed
             elif verb == 'not-installed':
                 return not installed
+
+        elif verb in ('envvar', 'not-envvar'):
+            if not arguments:
+                raise ValueError(
+                    "Environment variable name missing: %r" % expression
+                )
+            if len(arguments) > 1:
+                raise ValueError(
+                    "Only one environment variable name allowed: %r"
+                    % expression
+                )
+
+            if verb == 'envvar':
+                return self.context.hasEnvironmentVariable(arguments[0])
+            elif verb == 'not-envvar':
+                return not self.context.hasEnvironmentVariable(arguments[0])
+
         else:
             raise ValueError("Invalid ZCML condition: %r" % expression)
 

--- a/src/zope/configuration/xmlconfig.py
+++ b/src/zope/configuration/xmlconfig.py
@@ -278,7 +278,7 @@ class ConfigurationHandler(ContentHandler):
         ``expression`` is a string of the form "verb arguments".
 
         Currently the supported verbs are ``have``, ``not-have``,
-        ``installed`` and ``not-installed``.
+        ``installed``, ``not-installed``, ``envvar`` and ``not-envvar``.
 
         The ``have`` and ``not-have`` verbs each take one argument:
         the name of a feature:
@@ -342,6 +342,43 @@ class ConfigurationHandler(ContentHandler):
             Traceback (most recent call last):
               ...
             ValueError: Package name missing: 'installed'
+
+        The ``envvar`` and ``not-envvar`` verbs each take one argument:
+        the name of an environment variable:
+
+            >>> from zope.configuration.config import ConfigurationContext
+            >>> from zope.configuration.xmlconfig import ConfigurationHandler
+            >>> context = ConfigurationContext()
+            >>> c = ConfigurationHandler(context, testing=True)
+            >>> c.evaluateCondition("envvar SAMPLE_ZOPE_ENV_VAR")
+            False
+            >>> c.evaluateCondition("not-envvar SAMPLE_ZOPE_ENV_VAR")
+            True
+            >>> try:
+            ...     os.environ['SAMPLE_ZOPE_ENV_VAR'] = '1'
+            ...     c.evaluateCondition("envvar SAMPLE_ZOPE_ENV_VAR")
+            ... finally:
+            ...     del os.environ['SAMPLE_ZOPE_ENV_VAR']
+            True
+            >>> try:
+            ...     os.environ['SAMPLE_ZOPE_ENV_VAR'] = '1'
+            ...     c.evaluateCondition("not-envvar SAMPLE_ZOPE_ENV_VAR")
+            ... finally:
+            ...     del os.environ['SAMPLE_ZOPE_ENV_VAR']
+            False
+
+        Ill-formed expressions raise an error:
+
+            >>> c.evaluateCondition("envvar x y")
+            Traceback (most recent call last):
+              ...
+            ValueError: Only one environment variable name allowed: 'envvar x y'
+
+            >>> c.evaluateCondition("envvar")
+            Traceback (most recent call last):
+              ...
+            ValueError: Environment variable name missing: 'envvar'
+
         """
         arguments = expression.split(None)
         verb = arguments.pop(0)


### PR DESCRIPTION
Use ``envvar`` or ``not-envvar``.
``not-envvar`` is true when the variable is not set, is empty, or is one of the usual 'falsy' values like '0'.

This implements issue #63.