### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-6.1 (unreleased)
+7.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 7.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 6.0 (2024-12-06)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@
 
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -60,13 +59,10 @@ setup(name='zope.configuration',
       ],
       url='https://github.com/zopefoundation/zope.configuration',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope'],
       python_requires='>=3.9',
       extras_require={
           'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
-          'test': ['zope.testing', 'zope.testrunner']
+          'test': ['zope.testing', 'zope.testrunner >= 6.4']
       },
       install_requires=[
           'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read(*rnames):
 
 
 setup(name='zope.configuration',
-      version='6.1.dev0',
+      version='7.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.dev',
       description='Zope Configuration Markup Language (ZCML)',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
